### PR TITLE
feat: add date field in log template

### DIFF
--- a/src/main/java/org/qubership/log/provider/CustomMessageLogProvider.java
+++ b/src/main/java/org/qubership/log/provider/CustomMessageLogProvider.java
@@ -46,7 +46,7 @@ public class CustomMessageLogProvider extends LogProvider {
     }
 
     @Override
-    public String getFirstLineWithoutDate() {
+    public String getFirstLine() {
         return null;
     }
 

--- a/src/main/java/org/qubership/log/provider/LogProvider.java
+++ b/src/main/java/org/qubership/log/provider/LogProvider.java
@@ -51,9 +51,8 @@ public abstract class LogProvider {
         StringBuilder message = new StringBuilder();
         Integer linesCount = 1;
 
-        String date = dateFormat.format(new Date());
-        String firstLine = getFirstLineWithoutDate();
-        message.append(date).append(" ").append(firstLine);
+        String firstLine = getFirstLine();
+        message.append(firstLine);
 
         while (multiline && isEventHappen(multilineProbability)) {
             String secondLine = getSecondLine();
@@ -78,7 +77,7 @@ public abstract class LogProvider {
         metricsCollector.messageBytes.record(length);
     }
 
-    abstract public String getFirstLineWithoutDate();
+    abstract public String getFirstLine();
 
     abstract public String getSecondLine();
 

--- a/src/main/java/org/qubership/log/provider/WordLogProvider.java
+++ b/src/main/java/org/qubership/log/provider/WordLogProvider.java
@@ -55,7 +55,7 @@ public class WordLogProvider extends LogProvider  {
     }
 
     @Override
-    public String getFirstLineWithoutDate() {
+    public String getFirstLine() {
         return generateLogLine(new int[]{template.getWordLength().getFrom(), template.getWordLength().getTo()}, new int[]{template.getLogLength().getMin(), template.getLogLength().getMax()}, new int[]{template.getSymbolRange().getFrom(), template.getSymbolRange().getTo()});
     }
 


### PR DESCRIPTION
Initially date was always injected in the beginning of first line. This change is required at least for generating logs in klog format.