### PR TITLE
chore: adopt shared Renovate presets

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,27 @@
+name: Validate Renovate Config
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -15,6 +15,9 @@ jobs:
   validate-renovate-config:
     name: Validate renovate.json
     runs-on: ubuntu-latest
+    container:
+      image: renovate/renovate:43.285.4@sha256:bd7d8f646bf9d22aea995eaad06ec26c3f4fd4efbc36826024f5653006c9e7b1
+      options: --user 0
     permissions:
       contents: read
     steps:
@@ -24,4 +27,24 @@ jobs:
           persist-credentials: false
 
       - name: Validate renovate.json
-        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json
+        run: renovate-config-validator --strict --no-global renovate.json
+
+      - name: Resolve shared Renovate presets
+        shell: bash
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          LOG_FORMAT: json
+          LOG_LEVEL: warn
+        run: |
+          set -o pipefail
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+          validation_filter='fromjson? | select(.err.validationError? or .msg == "Repository has invalid config")'
+
+          renovate --platform=local --dry-run=extract 2>&1 | tee "$log_file"
+
+          if jq -R -e "$validation_filter" "$log_file" >/dev/null; then
+            echo "::error::Renovate could not resolve the repository configuration"
+            jq -R -r "$validation_filter | .err.validationError // .msg" "$log_file"
+            exit 1
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,7 @@
   "extends": [
     "github>Netcracker/renovate-config:base",
     "github>Netcracker/renovate-config:github-actions",
-    "github>Netcracker/renovate-config:netcracker-dependencies",
-    "schedule:monthly"
+    "github>Netcracker/renovate-config:netcracker-dependencies"
   ],
   "prConcurrentLimit": 20,
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:monthly"],
-  "labels": ["dependencies"],
+  "extends": [
+    "github>Netcracker/renovate-config:base",
+    "github>Netcracker/renovate-config:github-actions",
+    "github>Netcracker/renovate-config:netcracker-dependencies",
+    "schedule:monthly"
+  ],
   "prConcurrentLimit": 20,
   "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "actions-deps",
-      "separateMajorMinor": false
-    },
     {
       "matchManagers": ["maven"],
       "groupName": "maven-deps"


### PR DESCRIPTION
## Why

The repository duplicates organization Renovate settings.

## What

- Use the shared base, GitHub Actions, and Netcracker dependency presets.
- Inherit the shared weekly update schedule instead of the local monthly override.
- Preserve the Maven dependency group and PR concurrency.
- Validate `renovate.json` in CI.

Related shared configuration: [Netcracker/renovate-config#29](https://github.com/Netcracker/renovate-config/pull/29) and [Netcracker/renovate-config#31](https://github.com/Netcracker/renovate-config/pull/31).
